### PR TITLE
Fix method name for the layers example [ci skip]

### DIFF
--- a/docs/functions/creating.md
+++ b/docs/functions/creating.md
@@ -342,7 +342,7 @@ class ExampleFunction extends LambdaFunction
         //
     } // [tl! collapse-end]
     
-    public function timeout() 
+    public function layers() 
     {
         return [
             // Node Canvas from https://github.com/jwerre/node-canvas-lambda [tl! ~~]


### PR DESCRIPTION
Updates the layer example to use the proper `layers` method.