### PR TITLE
Add support for container images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 ## Unreleased 
 
+## 0.3.2 - 2021-08-13
+
+### Added
+
+- Support for Container Images. [#29](https://github.com/hammerstonedev/sidecar/pull/29)
+
 ## 0.3.1 - 2021-07-31
 
 ### Fixed

--- a/docs/functions/handlers-and-packages.md
+++ b/docs/functions/handlers-and-packages.md
@@ -398,18 +398,19 @@ class ScreenshotFunction extends LambdaFunction
 
 In addition to the standard runtimes AWS Lambda offers the ability to package your Lambda function code and dependencies as a container image of up to 10 GB in size. 
 
-To use a container image with Sidecar you must first build a docker image and push it to the Amazon Elastic Container Registry (ECR). See [the official docs](https://docs.aws.amazon.com/lambda/latest/dg/images-create.html) for step-by-step instructions.
+To use a container image with Sidecar you must first build a Lambda compatible docker image and push it to the Amazon Elastic Container Registry (ECR). See [the official docs](https://docs.aws.amazon.com/lambda/latest/dg/images-create.html) for step-by-step instructions.
 
-Once the container has been added to the registry update the function's `package` method to return the container's ECR Image URI as shown below. Finally, add the `packageType` method with a return value of 'Image'. Note that you do not need to return anything from the `handler` method.
+Once the container has been added to the registry update the Sidecar function's handler method to return the `Package::CONTAINER_HANDLER` constant. Finally, update the function's `package` method to return the ECR Image URI as shown below.
 
 ```php
 use Hammerstone\Sidecar\LambdaFunction;
+use Hammerstone\Sidecar\Package;
 
 class ExampleFunction extends LambdaFunction
 {
     public function handler()
     {
-        
+        return Package::CONTAINER_HANDLER;
     }
 
     public function package()
@@ -417,11 +418,6 @@ class ExampleFunction extends LambdaFunction
         return [
             'ImageUri' => '123456789012.dkr.ecr.us-east-1.amazonaws.com/hello-world:latest',
         ];
-    }
-    
-    public function packageType()
-    {
-        return 'Image';
     }
 }
 ```

--- a/docs/functions/handlers-and-packages.md
+++ b/docs/functions/handlers-and-packages.md
@@ -394,6 +394,40 @@ class ScreenshotFunction extends LambdaFunction
 }
 ```
 
+## Container Images
+
+In addition to the standard runtimes AWS Lambda offers the ability to package your Lambda function code and dependencies as a container image of up to 10 GB in size. 
+
+To use a container image with Sidecar you must first build a docker image and push it to the Amazon Elastic Container Registry (ECR). See [the official docs](https://docs.aws.amazon.com/lambda/latest/dg/images-create.html) for step-by-step instructions.
+
+Once the container has been added to the registry update the function's `package` method to return the container's ECR Image URI as shown below. Finally, add the `packageType` method with a return value of 'Image'. Note that you do not need to return anything from the `handler` method.
+
+```php
+use Hammerstone\Sidecar\LambdaFunction;
+
+class ExampleFunction extends LambdaFunction
+{
+    public function handler()
+    {
+        
+    }
+
+    public function package()
+    {
+        return [
+            'ImageUri' => '123456789012.dkr.ecr.us-east-1.amazonaws.com/hello-world:latest',
+        ];
+    }
+    
+    public function packageType()
+    {
+        return 'Image';
+    }
+}
+```
+
+With the above configuration in place you can create and activate the AWS Lambda function with the `artisan sidecar:deploy --activate` command. From there you can use Sidecar to interact with the container image in the same manner as traditional runtimes.
+
 ## Further Reading
 
 To read more about what you can and should include in your package, based on your runtime, see the following pages in Amazon's documentation:

--- a/src/Clients/LambdaClient.php
+++ b/src/Clients/LambdaClient.php
@@ -145,10 +145,15 @@ class LambdaClient extends BaseClient
         // and S3Key be top level instead of nested under `Code`.
         $code = [
             'FunctionName' => $config['FunctionName'],
-            'S3Bucket' => $config['Code']['S3Bucket'],
-            'S3Key' => $config['Code']['S3Key'],
             'Publish' => $config['Publish']
         ];
+
+        if($function->packageType() === 'Zip'){
+            $code['S3Bucket'] = $config['Code']['S3Bucket'];
+            $code['S3Key'] = $config['Code']['S3Key'];
+        }else{
+            $code = array_merge($code, $function->package());
+        }
 
         $config = Arr::except($config, ['Code', 'Publish']);
 

--- a/src/Clients/LambdaClient.php
+++ b/src/Clients/LambdaClient.php
@@ -148,10 +148,10 @@ class LambdaClient extends BaseClient
             'Publish' => $config['Publish']
         ];
 
-        if($function->packageType() === 'Zip'){
+        if ($function->packageType() === 'Zip') {
             $code['S3Bucket'] = $config['Code']['S3Bucket'];
             $code['S3Key'] = $config['Code']['S3Key'];
-        }else{
+        } else {
             $code = array_merge($code, $function->package());
         }
 

--- a/src/Deployment.php
+++ b/src/Deployment.php
@@ -105,7 +105,7 @@ class Deployment
     {
         Sidecar::log('Environment: ' . Sidecar::getEnvironment());
         Sidecar::log('Package Type: ' . $function->packageType());
-        if($function->packageType() === 'Zip'){
+        if ($function->packageType() === 'Zip') {
             Sidecar::log('Runtime: ' . $function->runtime());
         }
 

--- a/src/Deployment.php
+++ b/src/Deployment.php
@@ -104,7 +104,11 @@ class Deployment
     protected function deploySingle(LambdaFunction $function)
     {
         Sidecar::log('Environment: ' . Sidecar::getEnvironment());
-        Sidecar::log('Runtime: ' . $function->runtime());
+        Sidecar::log('Package Type: ' . $function->packageType());
+        if($function->packageType() === 'Zip'){
+            Sidecar::log('Runtime: ' . $function->runtime());
+        }
+
 
         $function->beforeDeployment();
 

--- a/src/LambdaFunction.php
+++ b/src/LambdaFunction.php
@@ -206,6 +206,10 @@ abstract class LambdaFunction
      */
     public function packageType()
     {
+        if ($this->handler() === Package::CONTAINER_HANDLER) {
+            return Package::CONTAINER_HANDLER;
+        }
+
         return 'Zip';
     }
 
@@ -348,10 +352,10 @@ abstract class LambdaFunction
             'PackageType' => $this->packageType(),
         ];
 
-         if ($this->packageType() !== 'Zip') {
-             $config = Arr::except($config, ['Runtime', 'Handler']);
-         }
+        if ($this->packageType() !== 'Zip') {
+            $config = Arr::except($config, ['Runtime', 'Handler']);
+        }
 
-         return $config;
+        return $config;
     }
 }

--- a/src/LambdaFunction.php
+++ b/src/LambdaFunction.php
@@ -199,18 +199,15 @@ abstract class LambdaFunction
     }
 
     /**
-     * The type of deployment package. Set to Image for container image and set Zip for .zip file archive.
+     * The type of deployment package. Set to Image for container
+     * image and set Zip for .zip file archive.
      *
      * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-lambda-2015-03-31.html#createfunction
      * @return string
      */
     public function packageType()
     {
-        if ($this->handler() === Package::CONTAINER_HANDLER) {
-            return Package::CONTAINER_HANDLER;
-        }
-
-        return 'Zip';
+        return $this->handler() === Package::CONTAINER_HANDLER ? 'Image' : 'Zip';
     }
 
     /**
@@ -249,6 +246,7 @@ abstract class LambdaFunction
      * If your file lived in a folder called "lambda", you can just prepend the
      * path to your handler, leaving you with e.g. "lambda/image.generate".
      *
+     * @see https://hammerstone.dev/sidecar/docs/main/functions/handlers-and-packages
      * @see https://docs.aws.amazon.com/aws-sdk-php/v2/api/class-Aws.Lambda.LambdaClient.html#_createFunction
      * @return string
      */
@@ -352,7 +350,10 @@ abstract class LambdaFunction
             'PackageType' => $this->packageType(),
         ];
 
-        if ($this->packageType() !== 'Zip') {
+        // For container image packages, we need to remove the Runtime
+        // and Handler since the container handles both of those
+        // things inherently.
+        if ($this->packageType() === 'Image') {
             $config = Arr::except($config, ['Runtime', 'Handler']);
         }
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -18,6 +18,11 @@ use ZipStream\ZipStream;
 class Package
 {
     /**
+     * @var string
+     */
+    public const CONTAINER_HANDLER = 'Image';
+
+    /**
      * @var array
      */
     protected $include = [];

--- a/src/Package.php
+++ b/src/Package.php
@@ -18,9 +18,13 @@ use ZipStream\ZipStream;
 class Package
 {
     /**
+     * If your package is a container image, it does not require
+     * a handler function. Use this constant instead.
+     *
+     * @see https://hammerstone.dev/sidecar/docs/main/functions/handlers-and-packages
      * @var string
      */
-    public const CONTAINER_HANDLER = 'Image';
+    public const CONTAINER_HANDLER = 'container';
 
     /**
      * @var array

--- a/tests/Unit/LambdaClientTest.php
+++ b/tests/Unit/LambdaClientTest.php
@@ -8,6 +8,7 @@ namespace Hammerstone\Sidecar\Tests\Unit;
 use Aws\Lambda\Exception\LambdaException;
 use Hammerstone\Sidecar\Clients\LambdaClient;
 use Hammerstone\Sidecar\Tests\Unit\Support\DeploymentTestFunction;
+use Hammerstone\Sidecar\Tests\Unit\Support\DeploymentTestFunctionWithImage;
 use Hammerstone\Sidecar\Tests\Unit\Support\EmptyTestFunction;
 use Illuminate\Support\Facades\Event;
 use Mockery;
@@ -194,6 +195,38 @@ class LambdaClientTest extends BaseTest
                 'S3Bucket' => 'test-bucket',
                 'S3Key' => 'test-key',
                 'Publish' => 'test-Publish',
+            ]);
+
+        $this->lambda->updateExistingFunction($function);
+    }
+
+    /** @test */
+    public function update_existing_image_function()
+    {
+        $function = new DeploymentTestFunctionWithImage;
+
+        $this->lambda->shouldReceive('functionExists')
+            ->once()
+            ->andReturn(false);
+
+        $this->lambda->shouldReceive('updateFunctionConfiguration')
+            ->once()
+            ->with([
+                'FunctionName' => 'test-FunctionName',
+                'Role' => null,
+                'Description' => 'test-Description [ffeb0fec]',
+                'Timeout' => 300,
+                'MemorySize' => 512,
+                'Layers' => [],
+                'PackageType' => 'Image',
+            ]);
+
+        $this->lambda->shouldReceive('updateFunctionCode')
+            ->once()
+            ->with([
+                'FunctionName' => 'test-FunctionName',
+                'Publish' => 'test-Publish',
+                'ImageUri' => '123.dkr.ecr.us-west-2.amazonaws.com/image:latest',
             ]);
 
         $this->lambda->updateExistingFunction($function);

--- a/tests/Unit/Support/DeploymentTestFunctionWithImage.php
+++ b/tests/Unit/Support/DeploymentTestFunctionWithImage.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @author Aaron Francis <aarondfrancis@gmail.com|https://twitter.com/aarondfrancis>
+ */
+
+namespace Hammerstone\Sidecar\Tests\Unit\Support;
+
+use Hammerstone\Sidecar\LambdaFunction;
+
+class DeploymentTestFunctionWithImage extends LambdaFunction
+{
+    public function handler()
+    {
+        //
+    }
+
+    public function packageType()
+    {
+        return 'Image';
+    }
+
+    public function package()
+    {
+        return [
+            'ImageUri' => '123.dkr.ecr.us-west-2.amazonaws.com/image:latest',
+        ];
+    }
+
+    public function nameWithPrefix()
+    {
+        return 'test-FunctionName';
+    }
+
+    public function description()
+    {
+        return 'test-Description';
+    }
+}

--- a/tests/Unit/Support/DeploymentTestFunctionWithImage.php
+++ b/tests/Unit/Support/DeploymentTestFunctionWithImage.php
@@ -6,17 +6,13 @@
 namespace Hammerstone\Sidecar\Tests\Unit\Support;
 
 use Hammerstone\Sidecar\LambdaFunction;
+use Hammerstone\Sidecar\Package;
 
 class DeploymentTestFunctionWithImage extends LambdaFunction
 {
     public function handler()
     {
-        //
-    }
-
-    public function packageType()
-    {
-        return 'Image';
+        return Package::CONTAINER_HANDLER;
     }
 
     public function package()


### PR DESCRIPTION
This pull request allows Sidecar to create AWS Lambda functions from [container images](https://docs.aws.amazon.com/lambda/latest/dg/lambda-images.html) that have been pushed to the Amazon Elastic Container Registry (ECR).

I needed this functionality to interact with a PyTorch model that exceeded the 250MB limit. With these changes I was able to use Sidecar to get a container image Lambda running alongside a traditional runtime in the same Laravel app. Everything's been working really well for me so far.

I tried to keep the changes as minimal as possible and avoid impacting any existing tests. It might make more sense to modify the execution path depending on the package type. But that would require more changes to the existing code.