### PR TITLE
Update package documentation to include note for shipping node_modules

### DIFF
--- a/docs/functions/handlers-and-packages.md
+++ b/docs/functions/handlers-and-packages.md
@@ -162,6 +162,10 @@ class ExampleFunction extends LambdaFunction
 }
 ```
 
+> Note; if you are using any external dependencies (i.e packages installed in your `node_modules`), you need to ship the dependencies also.
+> For example, if you have installed some Javascript packages for your Javascript function, and these were installed alongside your function in the `resources/lambda` folder, then you would need to include the whole directory as detailed above.
+> See the section below on "Strategies for Dealing With node_modules" for more control over this
+
 ## The Package Class
 
 If you need a little more fine-grained control over the packaging process, you can use the `Package` class instead of the simpler array format.


### PR DESCRIPTION
As a first time user of Sidecar, I was able to get a "Hello World" function running really fast, by following the documentation.

That said, I was building something that required external dependencies (e.g Axios, Twilio etc) and so created a local `package.json` and installed these dependencies.
I then wrote my function code to consume these dependencies, but after deploying would face issues with the dependencies not existing.

Slightly confused, I thought I needed to use one of the strategies for dealing with `node_modules` and so tried bundling my dependencies. This caused more issues for me, with errors about adapater functions not being defined etc - these were all package errors that appeared in the process of bundling.

With some help from a friend, we realised that this was because I had specified my package as:

```php
public function package()
{
    return [
        'resources/js/lambda/recordCall.js'
    ];
}
```

This meant I was only shipping that JS file and none of the `node_modules` required to power it.

This was resolved by shipping the whole directory:

```php
public function package()
{
    return [
        'resources/js/lambda/'
    ];
}
```

This PR attempts to improve the documentation around what to specify in the package section to make this clearer.