### PR TITLE
Add event invocation support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,15 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
+        "illuminate/support": "^7.0|^8.0",
         "illuminate/filesystem": "^7.0|^8.0",
         "illuminate/console": "^7.0|^8.0",
         "maennchen/zipstream-php": "^2.1",
         "guzzlehttp/guzzle": "^7.2",
-        "aws/aws-sdk-php": "^3.20.0",
-        "illuminate/support": "8.*",
-        "orchestra/testbench": "6.*"
+        "aws/aws-sdk-php": "^3.20.0"
     },
     "require-dev": {
+        "orchestra/testbench": "^5.0|^6.0",
         "mockery/mockery": "^1.3.3",
         "phpunit/phpunit": "^8.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,15 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "illuminate/support": "^7.0|^8.0",
         "illuminate/filesystem": "^7.0|^8.0",
         "illuminate/console": "^7.0|^8.0",
         "maennchen/zipstream-php": "^2.1",
         "guzzlehttp/guzzle": "^7.2",
-        "aws/aws-sdk-php": "^3.20.0"
+        "aws/aws-sdk-php": "^3.20.0",
+        "illuminate/support": "8.*",
+        "orchestra/testbench": "6.*"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0|^6.0",
         "mockery/mockery": "^1.3.3",
         "phpunit/phpunit": "^8.4"
     },

--- a/docs/functions/executing.md
+++ b/docs/functions/executing.md
@@ -37,7 +37,7 @@ exports.handler = async function (event) {
 }
 ```
 
-## Sync vs. Async
+## Sync vs. Async vs. Event
 
 By default, all executions of Sidecar functions are synchronous, meaning script execution will stop while the Lambda finishes and returns its result. This is the simplest method and probably fine for the majority of use cases. 
 
@@ -62,6 +62,20 @@ $result = Sidecar::execute(OgImage::class, $payload = [], $async = true);
 echo 'Image may or may not have finished generating yet!';
 ```
 
+Whilst the execution is asynchronous, it is expected that you wait for the response, which is documented more below. If you're looking for "fire-and-forget" style execution, where you don't care about the response and are happy for execution to occur in the background then you'll need to execute your function as an event.
+
+```php
+// Event execution using the class. 
+$result = OgImage::executeAsEvent();
+$result = OgImage::execute($payload = [], $async = false, $invocationType = 'Event');
+
+// Event execution using the facade.
+$result = Sidecar::executeAsEvent(OgImage::class);
+$result = Sidecar::execute(OgImage::class, $payload = [], $async = false, $invocationType = 'Event');
+
+echo 'Image may or may not have finished generating yet!';
+```
+
 ### Settled Results
 
 When your function is executed using one of the sync methods, the return value will be an instance of `SettledResult`. The Settled Result class is responsible for delivering the result of your Lambda, along with the logs and information about duration, memory used, etc.
@@ -70,7 +84,7 @@ You can read more about that in the [body](#result-body) and [logs & timing](#lo
 
 ### Pending Results
 
-If you function is invoked using one of the async methods, the return value will be an instance of `PendingResult`. This class is a thin wrapper around a Guzzle promise that represents your pending function execution.
+If your function is invoked using one of the async methods, the return value will be an instance of `PendingResult`. This class is a thin wrapper around a Guzzle promise that represents your pending function execution.
 
 Given a Pending Result, if you'd like to pause execution until the promise is settled, you can call `settled`. This will return a `SettledResult`.
 
@@ -89,6 +103,8 @@ $result = $result->settled();
 dump($result instanceof SettledResult);
 // true
 ```
+
+Using the async methods is powered by Guzzle promises. Given the limitations of the Guzzle async implementation, as it stands today, you need to wait for the response to ensure all your requests have been made.
 
 ### Working With Either
 

--- a/docs/functions/executing.md
+++ b/docs/functions/executing.md
@@ -62,7 +62,7 @@ $result = Sidecar::execute(OgImage::class, $payload = [], $async = true);
 echo 'Image may or may not have finished generating yet!';
 ```
 
-Whilst the execution is asynchronous, it is expected that you wait for the response, which is documented more below. If you're looking for "fire-and-forget" style execution, where you don't care about the response and are happy for execution to occur in the background then you'll need to execute your function as an event.
+Whilst the execution is asynchronous, it is expected that you wait for the response, which is documented more in the next section below. If you're looking for "fire-and-forget" style execution, where you don't care about the response and are happy for execution to occur in the background then you'll need to execute your function as an event.
 
 ```php
 // Event execution using the class. 

--- a/src/LambdaFunction.php
+++ b/src/LambdaFunction.php
@@ -22,9 +22,9 @@ abstract class LambdaFunction
      * @param  bool  $async
      * @return SettledResult|PendingResult
      */
-    public static function execute($payload = [], $async = false)
+    public static function execute($payload = [], $async = false, $invocationType = 'RequestResponse')
     {
-        return Sidecar::execute(static::class, $payload, $async);
+        return Sidecar::execute(static::class, $payload, $async, $invocationType);
     }
 
     /**
@@ -63,6 +63,17 @@ abstract class LambdaFunction
     public static function executeManyAsync($payloads)
     {
         return static::executeMany($payloads, $async = true);
+    }
+
+    /**
+     * Execute the current function asynchronously as an event. This is "fire-and-forget" style.
+     *
+     * @param  array  $payload
+     * @return PendingResult
+     */
+    public static function executeAsEvent($payload = [])
+    {
+        return static::execute($payload, $async = false, $invocationType = 'Event');
     }
 
     /**

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -62,7 +62,7 @@ class Manager
      * @throws Exceptions\SidecarException
      * @throws FunctionNotFoundException
      */
-    public function execute($function, $payload = [], $async = false)
+    public function execute($function, $payload = [], $async = false, $invocationType = 'RequestResponse')
     {
         // Could be a FQCN.
         if (is_string($function)) {
@@ -85,7 +85,7 @@ class Manager
                 // `RequestResponse` is a synchronous call, vs `Event` which
                 // is a fire-and-forget, we can make it async by using the
                 // invokeAsync method.
-                'InvocationType' => 'RequestResponse',
+                'InvocationType' => $invocationType,
 
                 // Include the execution log in the response.
                 'LogType' => 'Tail',
@@ -164,6 +164,19 @@ class Manager
     public function executeManyAsync($params)
     {
         return $this->executeMany($params, $async = true);
+    }
+
+    /**
+     * @param $function
+     * @param  array  $payload
+     * @return PendingResult|SettledResult
+     *
+     * @throws Exceptions\SidecarException
+     * @throws FunctionNotFoundException
+     */
+    public function executeAsEvent($function, $payload = [])
+    {
+        return $this->execute($function, $payload, $async = false, $invocationType = 'Event');
     }
 
     /**

--- a/tests/Unit/ExecuteTest.php
+++ b/tests/Unit/ExecuteTest.php
@@ -195,4 +195,79 @@ class ExecuteTest extends BaseTest
 
         $this->assertEvents();
     }
+
+    /** @test */
+    public function event_invocation_execution_by_function()
+    {
+        $this->mockInvoke([
+            'InvocationType' => 'Event',
+            'Payload' => '{"foo":"bar"}'
+        ]);
+
+        EmptyTestFunction::execute([
+            'foo' => 'bar'
+        ], $async = false, $invocationType = 'Event');
+
+        $this->assertEvents();
+    }
+
+    /** @test */
+    public function event_invocation_execution_by_function_with_event_helper()
+    {
+        $this->mockInvoke([
+            'InvocationType' => 'Event',
+            'Payload' => '{"foo":"bar"}'
+        ]);
+
+        EmptyTestFunction::executeAsEvent([
+            'foo' => 'bar'
+        ]);
+
+        $this->assertEvents();
+    }
+
+    /** @test */
+    public function event_invocation_execution_by_facade()
+    {
+        $this->mockInvoke([
+            'InvocationType' => 'Event',
+            'Payload' => '{"foo":"bar"}'
+        ]);
+
+        Sidecar::execute(EmptyTestFunction::class, [
+            'foo' => 'bar'
+        ], $async = false, $invocationType = 'Event');
+
+        $this->assertEvents();
+    }
+
+    /** @test */
+    public function event_invocation_execution_by_facade_directly()
+    {
+        $this->mockInvoke([
+            'InvocationType' => 'Event',
+            'Payload' => '{"foo":"bar"}'
+        ]);
+
+        Sidecar::executeAsEvent(EmptyTestFunction::class, [
+            'foo' => 'bar'
+        ]);
+
+        $this->assertEvents();
+    }
+
+    /** @test */
+    public function event_invocation_execution_by_facade_with_instantiated_class()
+    {
+        $this->mockInvoke([
+            'InvocationType' => 'Event',
+            'Payload' => '{"foo":"bar"}'
+        ]);
+
+        Sidecar::execute(new EmptyTestFunction, [
+            'foo' => 'bar'
+        ], $async = false, $invocationType = 'Event');
+
+        $this->assertEvents();
+    }
 }


### PR DESCRIPTION
There is a discussion in #35 that outlines what the issue was, and this PR addresses the issue by adding support for the `Event` `InvocationType`.

When invocating a Lambda as an `Event`, it is truly asynchronous and runs in the "background"; "fire-and-forget" style.

We leveraged the existing `execute` function and allowed the `InvocationType` to be passed in, which made sense given that you still invoke the Lambda in the same way, you just change the way its invocated.

We've added a convenience method to `executeAsEvent` to remove some of the overhead of passing through configuration options.

We considered adding a `executeAsEventAsync` to allow these to be triggered asynchronously, but we did question its usefulness and so opted to leave it out for now.
Given that the functions are invoked as events now, the API responds immediately meaning you only pause your execution for the time it takes to talk to AWS. If you're only invoking one function then there's no benefit to doing this asynchronously, but if you're invoking 10 functions then you might reach for this.
The current implementation doesn't prevent you doing this though, and it could be done like so:

```php
$result = OgImage::execute($payload = [], $async = true, $invocationType = 'Event');
```

Adding a convenience method isn't hard, so let me know if you want that added, we just didn't see a need for it right away.

I've done my best to follow the existing conventions in the tests, but the wording is a little awkward at first; let me know if you have any better suggestions!

h/t @rhysemmerson for his help.