### PR TITLE
Add option to change Lambda function architecture

### DIFF
--- a/src/Architecture.php
+++ b/src/Architecture.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Hammerstone\Sidecar;
+
+abstract class Architecture
+{
+    public const ARM64 = 'arm64';
+    public const X86_64 = 'x86_64';
+}

--- a/src/LambdaFunction.php
+++ b/src/LambdaFunction.php
@@ -216,6 +216,18 @@ abstract class LambdaFunction
     }
 
     /**
+     * The instruction set architecture for the Lambda function.
+     *
+     * @see https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html
+     *
+     * @return array
+     */
+    public function architectures()
+    {
+        return [Architecture::X86_64];
+    }
+
+    /**
      * The type of deployment package. Set to Image for container
      * image and set Zip for .zip file archive.
      *
@@ -357,6 +369,7 @@ abstract class LambdaFunction
         $config = [
             'FunctionName' => $this->nameWithPrefix(),
             'Runtime' => $this->runtime(),
+            'Architectures' => $this->architectures(),
             'Role' => config('sidecar.execution_role'),
             'Handler' => $this->handler(),
             'Code' => $this->packageType() === 'Zip'


### PR DESCRIPTION
This will add support to change the architecture from the Lambda function:
https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html

> Lambda functions that use arm64 architecture (AWS Graviton2 processor) can achieve significantly better price and performance than the equivalent function running on x86_64 architecture. Consider using arm64 for compute-intensive applications such as high-performance computing, video encoding, and simulation workloads.

Cheaper 💸  and improved performance 🚀 

**Side note:**
Lambda provides the following runtimes for the arm64 architecture. These runtimes all use the Amazon Linux 2 operating system.

- Node.js 12, Node.js 14
- Python 3.8, Python 3.9
- Java 8 (AL2), Java 11
- .NET Core 3.1
- Ruby 2.7
- Custom Runtime on Amazon Linux 2