### PR TITLE
Move all 409 logic into a middleware

### DIFF
--- a/tests/Unit/DeploymentTest.php
+++ b/tests/Unit/DeploymentTest.php
@@ -204,7 +204,6 @@ class DeploymentTest extends BaseTest
     {
         $this->lambda->shouldReceive('functionExists')->andReturn(true);
         $this->lambda->shouldReceive('getVersions')->andReturn([]);
-        $this->lambda->shouldReceive('waitUntil')->twice();
         $this->lambda->shouldReceive('updateExistingFunction')->once()->withArgs(function ($function) {
             return $function instanceof DeploymentTestFunctionWithVariables;
         });

--- a/tests/Unit/LambdaClientTest.php
+++ b/tests/Unit/LambdaClientTest.php
@@ -204,12 +204,6 @@ class LambdaClientTest extends BaseTest
                 ]
             ]);
 
-        $this->lambda->shouldReceive('waitUntil')
-            ->twice()
-            ->with('FunctionUpdated', [
-                'FunctionName' => 'test-FunctionName',
-            ]);
-
         $this->lambda->updateExistingFunction($function);
     }
 
@@ -246,12 +240,6 @@ class LambdaClientTest extends BaseTest
                 'Architectures' => [
                     Architecture::X86_64
                 ]
-            ]);
-
-        $this->lambda->shouldReceive('waitUntil')
-            ->twice()
-            ->with('FunctionUpdated', [
-                'FunctionName' => 'test-FunctionName',
             ]);
 
         $this->lambda->updateExistingFunction($function);


### PR DESCRIPTION
This PR moves all retry logic into a middleware. This is ideal for a few reasons:

- Previously I had littered `waitUntilFunctionUpdated` statements everywhere I thought they were necessary. I had missed a few historically and had to add them as I found errors. Now, every single request is guaranteed to be covered by the retry logic, so it doesn't matter if I missed one, anytime a 409 is thrown due to Pending state, we're good.
- The middleware *only* gets called when there is a 409. Using the old method we'd potentially waste requests waiting for something that was already done. Now we only wait for the function if it an error is thrown.
- This also covers *execution* of functions. That was a big part of it. Previously execution of functions could get hit with the 409 bug, because we certainly don't want to blindly `waitUntilFunctionUpdated` before calling `execute`. Now, we don't have to! If an execution fails due to 409, it will be seamlessly retried.

