### PR TITLE
Support for Laravel 9.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [ 7.2, 7.3, 7.4, 8.0 ]
-        laravel: [ 7.*, 8.* ]
+        laravel: [ 7.*, 8.*, 9.* ]
         dependency-version: [ prefer-lowest, prefer-stable ]
         include:
           - laravel: 7.*
@@ -23,10 +23,18 @@ jobs:
           - laravel: 8.*
             testbench: 6.*
 
+          - laravel: 9.*
+            testbench: 7.*
+
         exclude:
           # Laravel 8 requires PHP 7.3.
           - laravel: 8.*
             php: 7.2
+          - laravel: 9.*
+            php:
+              - 7.2
+              - 7.3
+              - 7.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,10 +33,11 @@ jobs:
 
             # Laravel 9 requires PHP 8.0
           - laravel: 9.*
-            php:
-              - 7.2
-              - 7.3
-              - 7.4
+            php: 7.2
+          - laravel: 9.*
+            php: 7.3
+          - laravel: 9.*
+            php: 7.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,9 +27,11 @@ jobs:
             testbench: 7.*
 
         exclude:
-          # Laravel 8 requires PHP 7.3.
+            # Laravel 8 requires PHP 7.3.
           - laravel: 8.*
             php: 7.2
+
+            # Laravel 9 requires PHP 8.0
           - laravel: 9.*
             php:
               - 7.2

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,9 @@
         "orchestra/testbench": "7.*"
     },
     "require-dev": {
-        "mockery/mockery": "^1.3.3"
+        "mockery/mockery": "^1.3.3",
+        "orchestra/testbench": "^6|^7",
+        "phpunit/phpunit": "^8|^9"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
         "guzzlehttp/guzzle": "^7.2",
         "aws/aws-sdk-php": "^3.20.0",
         "illuminate/support": "9.*",
-        "orchestra/testbench": "7.*"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.3",

--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,16 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
+        "illuminate/support": "^7.0|^8.0|^9.0",
         "illuminate/filesystem": "^7.0|^8.0|^9.0",
         "illuminate/console": "^7.0|^8.0|^9.0",
         "maennchen/zipstream-php": "^2.1",
         "guzzlehttp/guzzle": "^7.2",
-        "aws/aws-sdk-php": "^3.20.0",
-        "illuminate/support": "9.*",
+        "aws/aws-sdk-php": "^3.20.0"
     },
     "require-dev": {
+        "orchestra/testbench": "^5|^6|^7",
         "mockery/mockery": "^1.3.3",
-        "orchestra/testbench": "^6|^7",
         "phpunit/phpunit": "^8|^9"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -11,17 +11,16 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "illuminate/support": "^7.0|^8.0",
-        "illuminate/filesystem": "^7.0|^8.0",
-        "illuminate/console": "^7.0|^8.0",
+        "illuminate/filesystem": "^7.0|^8.0|^9.0",
+        "illuminate/console": "^7.0|^8.0|^9.0",
         "maennchen/zipstream-php": "^2.1",
         "guzzlehttp/guzzle": "^7.2",
-        "aws/aws-sdk-php": "^3.20.0"
+        "aws/aws-sdk-php": "^3.20.0",
+        "illuminate/support": "9.*",
+        "orchestra/testbench": "7.*"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0|^6.0",
-        "mockery/mockery": "^1.3.3",
-        "phpunit/phpunit": "^8.4"
+        "mockery/mockery": "^1.3.3"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,9 +13,9 @@
         <testsuite name="unit">
             <directory>tests/Unit</directory>
         </testsuite>
-<!--        <testsuite name="integration">-->
-<!--            <directory>tests/Integration</directory>-->
-<!--        </testsuite>-->
+        <testsuite name="integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
     </testsuites>
     <filter>
         <whitelist>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,9 +13,9 @@
         <testsuite name="unit">
             <directory>tests/Unit</directory>
         </testsuite>
-        <testsuite name="integration">
-            <directory>tests/Integration</directory>
-        </testsuite>
+<!--        <testsuite name="integration">-->
+<!--            <directory>tests/Integration</directory>-->
+<!--        </testsuite>-->
     </testsuites>
     <filter>
         <whitelist>

--- a/test
+++ b/test
@@ -1,7 +1,14 @@
 #!/bin/bash
 
+declare -a php_major_version=$(php -v | tac | tail -n 1 | cut -d " " -f 2 | cut -c 1)
+
 declare -a laravel=("7.*" "8.*")
 declare -a testbench=("5.*" "6.*")
+
+if [ $php_major_version == "8" ]; then
+    declare -a laravel=("9.*")
+    declare -a testbench=("7.*")
+fi
 
 for i in "${!laravel[@]}"
 do

--- a/test
+++ b/test
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-declare -a php_major_version=$(php -v | tac | tail -n 1 | cut -d " " -f 2 | cut -c 1)
+declare -a php_major_version=$(php -v | head -n 1 | cut -c 5)
 
 declare -a laravel=("7.*" "8.*")
 declare -a testbench=("5.*" "6.*")


### PR DESCRIPTION
This PR adds support for Laravel 9.x, all tests pass. A few depreciations are thrown because `ramsey/collections` and `ramsey/uuid` are not yet up to date.

## Summary
* A few depreciations due to `ramsey/collections` and `ramsey/uuid` not being up to date
* A condition in the `test` cript that runs the test for L9 if we're running PHP8 in development.
* Added an empty `tests/Integration` directory to fix failing tests for PHPUnit >9.

> Maybe consider removing support for 7.2 and 7.3 as they are deprecated.
