### PR TITLE
Add support for Guzzle v6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,12 @@
 name: Tests
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    types: [ opened, synchronize, reopened ]
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,10 @@ jobs:
           - laravel: 9.*
             php: 7.4
 
+            # Laravel 9 requires Guzzle ^7.2
+          - laravel: 9.*
+            guzzle: 6.*
+
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
           - laravel: 9.*
             guzzle: 6.*
 
-    name: PHP ${{ matrix.php }} L${{ matrix.laravel }} G${{ matrix.guzzle }} [${{ matrix.dependency-version }}]
+    name: P${{ matrix.php }} / L${{ matrix.laravel }} / G${{ matrix.guzzle }} / ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
           - laravel: 9.*
             guzzle: 6.*
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: PHP ${{ matrix.php }} L${{ matrix.laravel }} G${{ matrix.guzzle }} [${{ matrix.dependency-version }}]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         php: [ 7.2, 7.3, 7.4, 8.0 ]
         laravel: [ 7.*, 8.*, 9.* ]
+        guzzle: [ 6.*, 7.* ]
         dependency-version: [ prefer-lowest, prefer-stable ]
         include:
           - laravel: 7.*
@@ -61,7 +62,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer self-update ${{ matrix.composer-version }}
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "guzzlehttp/guzzle:${{ matrix.guzzle }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "illuminate/filesystem": "^7.0|^8.0|^9.0",
         "illuminate/console": "^7.0|^8.0|^9.0",
         "maennchen/zipstream-php": "^2.1",
-        "guzzlehttp/guzzle": "^7.2",
+        "guzzlehttp/guzzle": "^6.3|^7.2",
         "aws/aws-sdk-php": "^3.20.0"
     },
     "require-dev": {


### PR DESCRIPTION
Adds support for `Guzzle ^6.3`.

For projects that are still running Laravel 7.x / PHP 7.4 and can't update Guzzle (due to other dependencies issues).