### PR TITLE
Replace spaces with - in prefix too

### DIFF
--- a/src/LambdaFunction.php
+++ b/src/LambdaFunction.php
@@ -107,7 +107,11 @@ abstract class LambdaFunction
      */
     public function prefix()
     {
-        return 'SC-' . config('app.name') . '-' . Sidecar::getEnvironment() . '-';
+        return str_replace(
+            ' ',
+            '-',
+            'SC-' . config('app.name') . '-' . Sidecar::getEnvironment() . '-'
+        );
     }
 
     /**

--- a/tests/Unit/FunctionTest.php
+++ b/tests/Unit/FunctionTest.php
@@ -10,7 +10,7 @@ use Hammerstone\Sidecar\Tests\Unit\Support\EmptyTestFunction;
 class FunctionTest extends BaseTest
 {
     /** @test */
-    public function app_name_with_a_space_gets_dashed()
+    public function app_name_with_a_space_gets_dashed_name()
     {
         config([
             'app.name' => 'Amazing App'
@@ -19,6 +19,19 @@ class FunctionTest extends BaseTest
         $this->assertEquals(
             'SC-Amazing-App-testing-ecar-Tests-Unit-Support-EmptyTestFunction',
             (new EmptyTestFunction)->nameWithPrefix()
+        );
+    }
+
+    /** @test */
+    public function app_name_with_a_space_gets_dashed_prefix()
+    {
+        config([
+            'app.name' => 'Amazing App'
+        ]);
+
+        $this->assertEquals(
+            'SC-Amazing-App-testing-',
+            (new EmptyTestFunction)->prefix()
         );
     }
 


### PR DESCRIPTION
Calling prefix() independently of nameWithPrefix() results in a function prefix which has spaces in it, which is not valid for a Lambda function name.