### PR TITLE
Add ECR permissions to deployment user

### DIFF
--- a/src/Commands/Actions/CreateDeploymentUser.php
+++ b/src/Commands/Actions/CreateDeploymentUser.php
@@ -94,6 +94,13 @@ class CreateDeploymentUser extends BaseAction
                     'logs:FilterLogEvents',
                 ],
                 'Resource' => 'arn:aws:logs:*:*:log-group:/aws/lambda/*',
+            ], [
+                'Effect' => 'Allow',
+                'Action' => [
+                    'ecr:GetRepositoryPolicy',
+                    'ecr:SetRepositoryPolicy',
+                ],
+                'Resource' => '*',
             ]],
         ];
     }


### PR DESCRIPTION
Adds the `ecr:GetRepositoryPolicy` and `ecr:SetRepositoryPolicy` permissions to the deployment user that Sidecar creates during setup, so that Sidecar can read and pull container images from ECR without any additional configuration.

The underlying permissions that are required here are actually `ecr:BatchGetImage` and `ecr:GetDownloadUrlForLayer`, but they have to be set on the ECR repository itself, not on Lambda. As far as I know there isn't an easy way to do that during setup, or to ensure it'll continue to work on new ECR repositories. If the permissions aren't set on the repository Lambda can actually go and set them—and to do so it needs the two Policy permissions added in this PR.

AWS docs on this: https://docs.aws.amazon.com/lambda/latest/dg/configuration-images.html#configuration-images-permissions.

I tested this by re-configuring Sidecar from scratch, and it works as expected and has no issue using a container image.

Closes #61.