### PR TITLE
Gracefully handle unexpected log output

### DIFF
--- a/src/Results/SettledResult.php
+++ b/src/Results/SettledResult.php
@@ -13,6 +13,7 @@ use Hammerstone\Sidecar\LambdaFunction;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Throwable;
 
 class SettledResult implements Responsable, ResultContract
 {
@@ -211,29 +212,33 @@ class SettledResult implements Responsable, ResultContract
         $lines = explode("\n", $lines);
 
         $lines = array_map(function ($line) use (&$reportLineReached) {
-            if ($reportLineReached) {
-                return null;
+            try {
+                if ($reportLineReached) {
+                    return null;
+                }
+
+                if (Str::startsWith($line, 'START RequestId:')) {
+                    return $this->parseStartLine($line);
+                }
+
+                if (Str::startsWith($line, 'END RequestId:')) {
+                    return null;
+                }
+
+                if (Str::startsWith($line, 'REPORT RequestId')) {
+                    $reportLineReached = true;
+
+                    return $this->parseReportLine($line);
+                }
+
+                if ($line === '') {
+                    return null;
+                }
+
+                return $this->parseInfoLine($line);
+            } catch (Throwable $exception) {
+                return $this->unknownLine($line);
             }
-
-            if (Str::startsWith($line, 'START RequestId:')) {
-                return $this->parseStartLine($line);
-            }
-
-            if (Str::startsWith($line, 'END RequestId:')) {
-                return null;
-            }
-
-            if (Str::startsWith($line, 'REPORT RequestId')) {
-                $reportLineReached = true;
-
-                return $this->parseReportLine($line);
-            }
-
-            if ($line === '') {
-                return null;
-            }
-
-            return $this->parseInfoLine($line);
         }, $lines);
 
         return array_values(array_filter($lines));
@@ -251,12 +256,8 @@ class SettledResult implements Responsable, ResultContract
     {
         $parts = explode("\t", $line);
 
-        if (count($parts) === 1) {
-            return [
-                'timestamp' => now()->timestamp,
-                'level' => 'UNKNOWN',
-                'body' => $parts[0]
-            ];
+        if (count($parts) < 4) {
+            return $this->unknownLine($line);
         }
 
         $body = $parts[3];
@@ -269,6 +270,15 @@ class SettledResult implements Responsable, ResultContract
             'timestamp' => Carbon::make($parts[0])->timestamp,
             'level' => $parts[2],
             'body' => $body
+        ];
+    }
+    
+    protected function unknownLine($line)
+    {
+        return [
+            'timestamp' => now()->timestamp,
+            'level' => 'UNKNOWN',
+            'body' => $line,
         ];
     }
 

--- a/src/Results/SettledResult.php
+++ b/src/Results/SettledResult.php
@@ -272,7 +272,7 @@ class SettledResult implements Responsable, ResultContract
             'body' => $body
         ];
     }
-    
+
     protected function unknownLine($line)
     {
         return [


### PR DESCRIPTION
This is a band aid for #65 — it doesn't necessarily fix the issue, but it at least ensures that if Sidecar runs into log output that it doesn't expect, it doesn't completely fail.