### PR TITLE
Replace DIRECTORY_SEPARATOR with '/'

### DIFF
--- a/src/Package.php
+++ b/src/Package.php
@@ -413,7 +413,7 @@ class Package
     {
         $path = $this->removeBasePath($path);
 
-        return $this->getBasePath() . ($path ? DIRECTORY_SEPARATOR . $path : $path);
+        return $this->getBasePath() . ($path ? '/' . $path : $path);
     }
 
     /**


### PR DESCRIPTION
This pull request aims to fix zips created on windows with a broken folder structure which doesn't match the lambda function handler.