### PR TITLE
Move `S3Client` to the container.

### DIFF
--- a/src/Clients/Configurations/AwsClientConfiguration.php
+++ b/src/Clients/Configurations/AwsClientConfiguration.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Hammerstone\Sidecar\Clients\Configurations;
+
+use Hammerstone\Sidecar\Contracts\AwsClientConfiguration as AwsClientConfigurationContract;
+
+class AwsClientConfiguration implements AwsClientConfigurationContract
+{
+    public function getConfiguration()
+    {
+        $config = [
+            'version' => 'latest',
+            'region' => config('sidecar.aws_region'),
+        ];
+
+        $credentials = array_filter([
+            'key' => config('sidecar.aws_key'),
+            'secret' => config('sidecar.aws_secret'),
+        ]);
+
+        if ($credentials) {
+            $config['credentials'] = $credentials;
+        }
+
+        return $config;
+    }
+}

--- a/src/Clients/S3Client.php
+++ b/src/Clients/S3Client.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Hammerstone\Sidecar\Clients;
+
+use Aws\S3\S3Client as BaseClient;
+
+class S3Client extends BaseClient
+{
+}

--- a/src/Contracts/AwsClientConfiguration.php
+++ b/src/Contracts/AwsClientConfiguration.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Hammerstone\Sidecar\Contracts;
+
+interface AwsClientConfiguration
+{
+    /**
+     * Retrieve an array of configuration options for Lambda,
+     * Cloudwatch and S3 AWS services.
+     *
+     * @return array
+     */
+    public function getConfiguration();
+}

--- a/src/Package.php
+++ b/src/Package.php
@@ -5,13 +5,14 @@
 
 namespace Hammerstone\Sidecar;
 
-use Aws\S3\S3Client;
+use Hammerstone\Sidecar\Clients\S3Client;
 use Hammerstone\Sidecar\Exceptions\SidecarException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
+use ZipStream\Exception;
 use ZipStream\Option\Archive;
 use ZipStream\Option\File as FileOptions;
 use ZipStream\ZipStream;
@@ -281,7 +282,7 @@ class Package
     {
         try {
             $key = $this->upload();
-        } catch (\ZipStream\Exception $e) {
+        } catch (Exception $e) {
             throw new SidecarException('Sidecar could not create ZIP: ' . $e->getMessage());
         }
 
@@ -306,7 +307,7 @@ class Package
     /**
      * @return string
      *
-     * @throws \ZipStream\Exception
+     * @throws Exception
      */
     public function upload()
     {
@@ -442,21 +443,12 @@ class Package
     }
 
     /**
-     * @return string
+     * @return void
      */
     protected function registerStreamWrapper()
     {
         // Register the s3:// stream wrapper.
         // https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/s3-stream-wrapper.html
-        $client = new S3Client([
-            'version' => 'latest',
-            'region' => config('sidecar.aws_region'),
-            'credentials' => [
-                'key' => config('sidecar.aws_key'),
-                'secret' => config('sidecar.aws_secret'),
-            ]
-        ]);
-
-        $client->registerStreamWrapper();
+        app(S3Client::class)->registerStreamWrapper();
     }
 }


### PR DESCRIPTION
Howdy!

So, here's the deal. Currently, both `LambdaClient` and `CloudWatchLogsClient` are [bound in the Laravel container](https://github.com/lukeraymonddowning/sidecar/blob/00d5ce0a325367554d9f307551043042910f6d12/src/Providers/SidecarServiceProvider.php#L26), which is wonderful, because that means if we need to override that binding in user-land, we can. 😈

However, in `Hammerstone\Sidecar\Package.php`, the `S3Client` is [currently being manually instantiated](https://github.com/lukeraymonddowning/sidecar/blob/ca923f77a1b0fbfecd9493aa57b7ec5e1c37fef2/src/Package.php#L447), which means that

1. It doesn't share the same paradigm as the other two services
2. It can't be overridden by an end user ([without some seriously crazy composer hacks](https://downing.tech/posts/overriding-vendor-classes))

This PR aims to fix that with the following steps:

1. We place AWS' `S3Client` behind a Hammerstone `S3Client` that extends the former
2. We bind that new `S3Client` in the `SidecarServiceProvider`
3. We update `Package` to make use of this bound `S3Client` rather than manually instantiating

Whilst I was at it, I realised that what I actually tend to want as a user is to return a custom configuration array for all three services: Lambda, CloudWatch and S3 (for example, if I'm using token auth as an added layer of security). To help make it simple for a user to provide a custom config array for these services, I've made the following adjustments/additions:

1. Created a new contract: `AwsClientConfiguration`, which expects implementations to return a config array
2. Created a default implementation which simply performs the logic [that was found in `SidecarServiceProvider::getAwsClientConfiguration` previously](https://github.com/lukeraymonddowning/sidecar/blob/00d5ce0a325367554d9f307551043042910f6d12/src/Providers/SidecarServiceProvider.php#L35)
3. Bound that default implementation and used it for all three services in the container

There is a case I think for also passing the client FQCN as a parameter to the `AwsClientConfiguration::getConfiguration` method, which would allow for passing slightly different configurations depending on the service being used, but I opted not to add that in just yet pending your opinion.

Any how, any questions let me know!

Kind Regards,
Luke