### PR TITLE
Fix for specifying a directory in a package when deploying from windows

### DIFF
--- a/src/Finder.php
+++ b/src/Finder.php
@@ -101,7 +101,7 @@ class Finder
                 continue;
             }
 
-            yield $file->getPathname();
+            yield $file->getPath() . '/'. $file->getFilename();
         }
     }
 

--- a/src/Finder.php
+++ b/src/Finder.php
@@ -101,7 +101,7 @@ class Finder
                 continue;
             }
 
-            yield $file->getPath() . '/'. $file->getFilename();
+            yield $file->getPathname();
         }
     }
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -305,6 +305,14 @@ class Package
 
     /**
      * @return string
+     */
+    public function normalizeSeparators($file) 
+    {
+        return str_replace(DIRECTORY_SEPARATOR, '/', $file);
+    }
+
+    /**
+     * @return string
      *
      * @throws \ZipStream\Exception
      */
@@ -350,19 +358,19 @@ class Package
             // Remove the base path so that everything inside
             // the zip is relative to the project root.
             $zip->addFileFromPath(
-                $this->removeBasePath($file), $file, $options
+                $this->normalizeSeparators($this->removeBasePath($file)), $file, $options
             );
         }
 
         foreach ($this->exactIncludes as $source => $destination) {
             $zip->addFileFromPath(
-                $destination, $source, $options
+                $this->normalizeSeparators($destination), $source, $options
             );
         }
 
         foreach ($this->stringContents as $destination => $stringContent) {
             $zip->addFile(
-                $destination, $stringContent, $options
+                $this->normalizeSeparators($destination), $stringContent, $options
             );
         }
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -306,7 +306,7 @@ class Package
     /**
      * @return string
      */
-    public function normalizeSeparators($file) 
+    public function normalizeSeparators($file)
     {
         return str_replace(DIRECTORY_SEPARATOR, '/', $file);
     }


### PR DESCRIPTION
When using specifying a directory in the package function windows paths becomes a mix of \ and /.

This commit changes the way the Finder class retrieves the path.

Since `SplFileInfo::getPathname` returns a mixture of paths on windows and creating zips on windows really likes / . I replaced the call to `getPathname()` with `$file->getPath() . '/'. $file->getFilename()` both functions on `SplFileInfo`

This means the \ that gets added between the folder and file in question is always a /.

This change may need testing on other platforms but should be okay.