### PR TITLE
Tiemout is specified in seconds

### DIFF
--- a/src/LambdaFunction.php
+++ b/src/LambdaFunction.php
@@ -301,7 +301,7 @@ abstract class LambdaFunction
     }
 
     /**
-     * The function execution time, in MS, at which Lambda should terminate the function.
+     * The function execution time, in seconds, at which Lambda should terminate the function.
      * Because the execution time has cost implications, we recommend you set this
      * value based on your expected execution time.
      *


### PR DESCRIPTION
This just fixes a typo in the Doc blocks which says that timeout must be passed in ms when instead it must be passed in seconds like the AWS documentation says

https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-lambda-2015-03-31.html#createfunction