### PR TITLE
BREAKING CHANGE: Removing unsupported runtimes

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -10,18 +10,13 @@ You can write functions in any of the following runtimes and execute them straig
 - Node.js 16
 - Node.js 14
 - Node.js 12
-- Node.js 10
 - Python 3.8
 - Python 3.7
-- Python 3.6
-- Python 2.7
 - Ruby 2.7
-- Ruby 2.5
 - Java 11
 - Java 8
 - Go 1.x
 - .NET Core 3.1
-- .NET Core 2.1
 
 Any runtime that [Lambda supports](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html), you can use!
 

--- a/src/Deployment.php
+++ b/src/Deployment.php
@@ -6,6 +6,7 @@
 namespace Hammerstone\Sidecar;
 
 use Exception;
+use Illuminate\Support\Str;
 use Hammerstone\Sidecar\Clients\LambdaClient;
 use Hammerstone\Sidecar\Events\AfterFunctionsActivated;
 use Hammerstone\Sidecar\Events\AfterFunctionsDeployed;
@@ -209,7 +210,7 @@ class Deployment
         $results = Sidecar::warmSingle($function, $async = false, $version);
 
         if ($warmed = count($results)) {
-            Sidecar::log("Warmed $warmed instances.");
+            Sidecar::log("Warmed $warmed " . Str::plural("instance", $warmed));
         } else {
             Sidecar::log('No instances warmed. If this is unexpected, confirm your `warmingConfig` method is set up correctly.');
         }

--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -30,7 +30,5 @@ abstract class Runtime
 
     public const DOT_NET_31 = 'dotnetcore3.1';
 
-    public const DOT_NET_21 = 'dotnetcore2.1';
-
     public const PROVIDED_AL2 = 'provided.al2';
 }

--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -10,22 +10,14 @@ abstract class Runtime
 
     public const NODEJS_12 = 'nodejs12.x';
 
-    public const NODEJS_10 = 'nodejs10.x';
-
     public const PYTHON_39 = 'python3.9';
 
     public const PYTHON_38 = 'python3.8';
 
     public const PYTHON_37 = 'python3.7';
 
-    public const PYTHON_36 = 'python3.6';
-
-    public const PYTHON_27 = 'python2.7';
-
     public const RUBY_27 = 'ruby2.7';
-
-    public const RUBY_25 = 'ruby2.5';
-
+    
     public const JAVA_11 = 'java11';
 
     public const JAVA_8_LINUX2 = 'java8.al2';


### PR DESCRIPTION
As per https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy removed deprecated runtimes:

```
NODEJS_10
PYTHON3_6
PYTHON2_7
RUBY2_5
DOT_NET_21
```

Also updated the pre-warm notice to use the `Str::plural()` helper