### PR TITLE
Add Support for Laravel 10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [ 7.2, 7.3, 7.4, 8.0, 8.1 ]
-        laravel: [ 7.*, 8.*, 9.* ]
+        laravel: [ 7.*, 8.*, 9.*, 10.* ]
         guzzle: [ 6.*, 7.* ]
         dependency-version: [ prefer-lowest, prefer-stable ]
         include:
@@ -31,6 +31,9 @@ jobs:
 
           - laravel: 9.*
             testbench: 7.*
+
+          - laravel: 10.*
+            testbench: 8.*
 
         exclude:
           - laravel: 7.*
@@ -55,6 +58,20 @@ jobs:
 
             # Laravel 9 requires Guzzle ^7.2
           - laravel: 9.*
+            guzzle: 6.*
+
+            # Laravel 10 requires PHP 8.1
+          - laravel: 10.*
+            php: 7.2
+          - laravel: 10.*
+            php: 7.3
+          - laravel: 10.*
+            php: 7.4
+          - laravel: 10.*
+            php: 8.0
+
+            # Laravel 10 requires Guzzle ^7.2
+          - laravel: 10.*
             guzzle: 6.*
 
     name: P${{ matrix.php }} / L${{ matrix.laravel }} / G${{ matrix.guzzle }} / ${{ matrix.dependency-version }}

--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,15 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "illuminate/support": "^7.0|^8.0|^9.0",
-        "illuminate/filesystem": "^7.0|^8.0|^9.0",
-        "illuminate/console": "^7.0|^8.0|^9.0",
+        "illuminate/support": "^7.0|^8.0|^9.0|^10",
+        "illuminate/filesystem": "^7.0|^8.0|^9.0|^10",
+        "illuminate/console": "^7.0|^8.0|^9.0|^10",
         "maennchen/zipstream-php": "^2.1",
         "guzzlehttp/guzzle": "^6.3|^7.2",
         "aws/aws-sdk-php": "^3.216.1"
     },
     "require-dev": {
-        "orchestra/testbench": "^5|^6|^7",
+        "orchestra/testbench": "^5|^6|^7|^8",
         "mockery/mockery": "^1.3.3",
         "phpunit/phpunit": ">=8.5.23|^9"
     },


### PR DESCRIPTION
Update version constraints in composer.json to support Laravel 10.
GitHub Actions workflow has also been updated to test Sidecar on Laravel 10 (Laravel 10 requires PHP 8.1, so all PHP version have been excluded).

Support for PHP 8.2 has been covered in #98.