### PR TITLE
Documents command options

### DIFF
--- a/src/Commands/Activate.php
+++ b/src/Commands/Activate.php
@@ -16,7 +16,8 @@ class Activate extends EnvironmentAwareCommand
      *
      * @var string
      */
-    protected $signature = 'sidecar:activate {--pre-warm}';
+    protected $signature = 'sidecar:activate
+                            {--pre-warm : Send warming requests to Sidecar functions}';
 
     /**
      * The console command description.

--- a/src/Commands/Activate.php
+++ b/src/Commands/Activate.php
@@ -23,7 +23,7 @@ class Activate extends EnvironmentAwareCommand
      *
      * @var string
      */
-    protected $description = 'Activate Sidecar functions that have already been deployed.';
+    protected $description = 'Activate Sidecar functions that have already been deployed';
 
     /**
      * @throws NoFunctionsRegisteredException

--- a/src/Commands/Configure.php
+++ b/src/Commands/Configure.php
@@ -28,7 +28,7 @@ class Configure extends Command
      *
      * @var string
      */
-    protected $description = 'Interactively configure your Sidecar AWS environment variables.';
+    protected $description = 'Interactively configure your Sidecar AWS environment variables';
 
     /**
      * @var string
@@ -70,11 +70,11 @@ class Configure extends Command
 
         $this->line(' ');
         $this->info('Done! Here are your environment variables:');
-        $this->line('SIDECAR_ACCESS_KEY_ID=' . $credentials['key']);
-        $this->line('SIDECAR_SECRET_ACCESS_KEY=' . $credentials['secret']);
-        $this->line('SIDECAR_REGION=' . $this->region);
-        $this->line('SIDECAR_ARTIFACT_BUCKET_NAME=' . $bucket);
-        $this->line('SIDECAR_EXECUTION_ROLE=' . $role);
+        $this->line('SIDECAR_ACCESS_KEY_ID='.$credentials['key']);
+        $this->line('SIDECAR_SECRET_ACCESS_KEY='.$credentials['secret']);
+        $this->line('SIDECAR_REGION='.$this->region);
+        $this->line('SIDECAR_ARTIFACT_BUCKET_NAME='.$bucket);
+        $this->line('SIDECAR_EXECUTION_ROLE='.$role);
         $this->line(' ');
         $this->info('They will work in any environment.');
     }
@@ -92,9 +92,9 @@ class Configure extends Command
                 'version' => 'latest',
                 'credentials' => [
                     'key' => $this->key,
-                    'secret' => $this->secret
-                ]
-            ]
+                    'secret' => $this->secret,
+                ],
+            ],
         ]);
     }
 

--- a/src/Commands/Deploy.php
+++ b/src/Commands/Deploy.php
@@ -23,7 +23,7 @@ class Deploy extends EnvironmentAwareCommand
      *
      * @var string
      */
-    protected $description = 'Deploy Sidecar functions.';
+    protected $description = 'Deploy Sidecar functions';
 
     /**
      * @throws NoFunctionsRegisteredException

--- a/src/Commands/Deploy.php
+++ b/src/Commands/Deploy.php
@@ -16,7 +16,9 @@ class Deploy extends EnvironmentAwareCommand
      *
      * @var string
      */
-    protected $signature = 'sidecar:deploy {--activate} {--pre-warm}';
+    protected $signature = 'sidecar:deploy 
+                            {--activate : Activate the deployment after deploying} 
+                            {--pre-warm : Send warming requests to Sidecar functions}';
 
     /**
      * The console command description.

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -23,7 +23,7 @@ class Install extends Command
      *
      * @var string
      */
-    protected $description = 'Install the Sidecar config file into your app.';
+    protected $description = 'Install the Sidecar config file into your app';
 
     public function __construct()
     {
@@ -40,7 +40,7 @@ class Install extends Command
     public function handle()
     {
         Artisan::call('vendor:publish', [
-            '--provider' => SidecarServiceProvider::class
+            '--provider' => SidecarServiceProvider::class,
         ]);
 
         $this->info('Config file published!');

--- a/src/Commands/Warm.php
+++ b/src/Commands/Warm.php
@@ -22,7 +22,7 @@ class Warm extends EnvironmentAwareCommand
      *
      * @var string
      */
-    protected $description = 'Send warming requests to Sidecar functions.';
+    protected $description = 'Send warming requests to Sidecar functions';
 
     /**
      * @throws Exception


### PR DESCRIPTION
The PR makes two small updates to commands. First, I've removed the period from the end of the command description to be consistent with commands that ship with Laravel:

<img width="721" alt="Screenshot 2023-03-14 at 10 26 24" src="https://user-images.githubusercontent.com/3438564/224975199-9ceb0bb6-df4f-40a6-9f55-f0e19590f2d3.png">

I have also added descriptions for the `--pre-warm` and `--activate` options.

<img width="954" alt="Screenshot 2023-03-14 at 10 35 13" src="https://user-images.githubusercontent.com/3438564/224975547-e6299de3-df95-4212-871a-c78b24a48b8a.png">

<img width="959" alt="Screenshot 2023-03-14 at 10 35 27" src="https://user-images.githubusercontent.com/3438564/224975551-32c61ecd-85d4-4c36-887b-184f0e0b515a.png">


Pint also made some minor code formatting tweaks.
