### PR TITLE
Update supported Runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,21 +23,20 @@ You can write functions in any of the following runtimes and execute them straig
 - Node.js 20
 - Node.js 18
 - Node.js 16
-- Node.js 14
+- Python 3.12
 - Python 3.11
 - Python 3.10
 - Python 3.9
 - Python 3.8
-- Python 3.7
-- Ruby 3.2
-- Ruby 2.7
+- Java 21
 - Java 17
 - Java 11
 - Java 8
-- Go 1.x
 - .NET 7
 - .NET 6
-- Custom runtime
+- Ruby 3.2
+- OS-only runtime (Amazon Linux 2023)
+- OS-only runtime (Amazon Linux 2)
 
 Any runtime that [Lambda supports](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html), you can use!
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Sidecar packages, creates, deploys, and executes Lambda functions from your Lara
 
 You can write functions in any of the following runtimes and execute them straight from PHP:
 
+- Node.js 20
 - Node.js 18
 - Node.js 16
 - Node.js 14

--- a/README.md
+++ b/README.md
@@ -20,23 +20,22 @@ Sidecar packages, creates, deploys, and executes Lambda functions from your Lara
 
 You can write functions in any of the following runtimes and execute them straight from PHP:
 
+- Node.js 18
 - Node.js 16
 - Node.js 14
-- Node.js 12
-- Node.js 10
+- Python 3.10
 - Python 3.9
 - Python 3.8
 - Python 3.7
-- Python 3.6
-- Python 2.7
+- Ruby 3.2
 - Ruby 2.7
-- Ruby 2.5
+- Java 17
 - Java 11
 - Java 8
 - Go 1.x
+- .NET 7
 - .NET 6
-- .NET Core 3.1
-- .NET Core 2.1
+- Custom runtime
 
 Any runtime that [Lambda supports](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html), you can use!
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ You can write functions in any of the following runtimes and execute them straig
 - Node.js 18
 - Node.js 16
 - Node.js 14
+- Python 3.11
 - Python 3.10
 - Python 3.9
 - Python 3.8

--- a/docs/functions/customization.md
+++ b/docs/functions/customization.md
@@ -10,6 +10,7 @@ Lambda supports multiple languages through the use of runtimes. You can choose a
 - Node.js 18: `nodejs18.x`
 - Node.js 16: `nodejs16.x`
 - Node.js 14: `nodejs14.x`
+- Python 3.11: `python3.11`
 - Python 3.10: `python3.10`
 - Python 3.9: `python3.9`
 - Python 3.8: `python3.8`

--- a/docs/functions/customization.md
+++ b/docs/functions/customization.md
@@ -7,21 +7,24 @@ The only two things _required_ for a Sidecar function are the [package and the h
 
 Lambda supports multiple languages through the use of runtimes. You can choose any of the following runtimes by returning its corresponding identifier:
 
+- Node.js 18: `nodejs18.x`
 - Node.js 16: `nodejs16.x`
 - Node.js 14: `nodejs14.x`
-- Node.js 12: `nodejs12.x`
-- Node.js 10: `nodejs10.x`
+- Python 3.10: `python3.10`
+- Python 3.9: `python3.9`
 - Python 3.8: `python3.8`
 - Python 3.7: `python3.7`
-- Python 3.6: `python3.6`
-- Python 2.7: `python2.7`
+- Ruby 3.2: `ruby3.2`
 - Ruby 2.7: `ruby2.7`
-- Ruby 2.5: `ruby2.5`
+- Java 17: `java17`
 - Java 11: `java11`
 - Java 8: `java8`
+- Java 8 Linux 2: `java8.al2`
 - Go 1.x: `go1.x`
-- .NET Core 3.1: `dotnetcore3.1`
-- .NET Core 2.1: `dotnetcore2.1`
+- .NET 7: `dotnet7`
+- .NET 6: `dotnet6`
+- Custom runntime: `provided.al2`
+- Custom runntime: `provided`
 
 E.g. to use the Go runtime, you would return `go1.x`:
 

--- a/docs/functions/customization.md
+++ b/docs/functions/customization.md
@@ -7,6 +7,7 @@ The only two things _required_ for a Sidecar function are the [package and the h
 
 Lambda supports multiple languages through the use of runtimes. You can choose any of the following runtimes by returning its corresponding identifier:
 
+- Node.js 20: `nodejs20.x`
 - Node.js 18: `nodejs18.x`
 - Node.js 16: `nodejs16.x`
 - Node.js 14: `nodejs14.x`

--- a/docs/functions/customization.md
+++ b/docs/functions/customization.md
@@ -10,32 +10,29 @@ Lambda supports multiple languages through the use of runtimes. You can choose a
 - Node.js 20: `nodejs20.x`
 - Node.js 18: `nodejs18.x`
 - Node.js 16: `nodejs16.x`
-- Node.js 14: `nodejs14.x`
+- Python 3.12: `python3.12`
 - Python 3.11: `python3.11`
 - Python 3.10: `python3.10`
 - Python 3.9: `python3.9`
 - Python 3.8: `python3.8`
-- Python 3.7: `python3.7`
-- Ruby 3.2: `ruby3.2`
-- Ruby 2.7: `ruby2.7`
+- Java 21: `java21`
 - Java 17: `java17`
 - Java 11: `java11`
-- Java 8: `java8`
-- Java 8 Linux 2: `java8.al2`
-- Go 1.x: `go1.x`
+- Java 8: `java8.al2`
 - .NET 7: `dotnet7`
 - .NET 6: `dotnet6`
-- Custom runntime: `provided.al2`
-- Custom runntime: `provided`
+- Ruby 3.2: `ruby3.2`
+- OS-only runtime (Amazon Linux 2023): `provided.al2023`
+- OS-only runtime (Amazon Linux 2): `provided.al2`
 
-E.g. to use the Go runtime, you would return `go1.x`:
+E.g. to use the Python 3.12 runtime, you would return `python3.12`:
 
 ```php
 class ExampleFunction extends LambdaFunction
 {
     public function runtime() // [tl! focus:3]
     {
-        return 'go1.x';
+        return 'python3.12';
     }
 }
 ```

--- a/docs/functions/deploying.md
+++ b/docs/functions/deploying.md
@@ -22,7 +22,7 @@ When you run that, you'll see an output log similar to the one below:
           ↳ Activating Version 1 of SC-Laravel-local-Sidecar-OgImage.
 ```
 
-The deployment process consists of 
+The deployment process consists of
 - zipping the handler code
 - uploading the zip file to S3
 - creating the Lambda function if it doesn't exist
@@ -37,7 +37,7 @@ There are two required steps in order to make your functions live and usable.
 
 Because your handler code may require you to `npm install`, `bundle install`, or something similar, you may be building and deploying your handler code in CI or from your local computer.
 
-Once that handler code is all bundled and deployed to Lambda, there may be a secondary step required to deploy your main application. 
+Once that handler code is all bundled and deployed to Lambda, there may be a secondary step required to deploy your main application.
 
 During this secondary step, your Lambda functions are going to be updated but your application code will not be, which could lead to errors for your users.
 
@@ -75,15 +75,15 @@ environments:
       - 'php artisan sidecar:deploy --env=production' # [tl! ~~]
     deploy: # [tl! ~~]
       - 'php artisan sidecar:activate' # [tl! ~~]
-```  
+```
 
 Your functions would be built and deployed on whatever machine is handling the Vapor deploy process, and then would be activated as Vapor activates your newest application code.
 
 > Note that in this example we're setting the environment to "production" in the build, because it's likely that your "build" step is running in an environment that doesn't have it's ENV set to "production." See below for more details.
 
 ## Faking the Environment
- 
-Sidecar names your function based on environment, to prevent collisions between local, staging, production, etc. This could pose a problem if you are deploying your production functions from your build or CI server. 
+
+Sidecar names your function based on environment, to prevent collisions between local, staging, production, etc. This could pose a problem if you are deploying your production functions from your build or CI server.
 
 If you need to deploy an environment other than the one you are in, you can override the environment from the config by passing an `--env` flag to the Deploy and Activate commands.
 
@@ -96,7 +96,7 @@ To read more about environments, head to the [Environments section](../environme
 
 ## Setting Environment Variables
 
-This is covered in the [Environment Variables](customization#environment-variables) section of the Customization docs, but we'll cover strategies around env vars and deployment here. 
+This is covered in the [Environment Variables](customization#environment-variables) section of the Customization docs, but we'll cover strategies around env vars and deployment here.
 
 Some of your functions will require environment variables, either from your Laravel application or something completely distinct. In some cases, you may need to set a static variable so that some library will work [(LibreOffice example)](https://github.com/hammerstonedev/sidecar/issues/24):
 
@@ -159,7 +159,7 @@ Sidecar sets the environment variables _upon activation_. If you are deploying f
 
 Environment variables are set before activation, and before any pre-warming takes place.
 
-And remember! If Sidecar manages the environment variables for a function, it will clobber any changes you make in the AWS UI, so you cannot use both methods simultaneously.  
+And remember! If Sidecar manages the environment variables for a function, it will clobber any changes you make in the AWS UI, so you cannot use both methods simultaneously.
 
 ## Reusing Package Files
 
@@ -172,15 +172,11 @@ In the event that neither the code nor function configuration have changed, Side
 You will see output similar to the following:
 
 ```text
-[Sidecar] Deploying App\Sidecar\OgImage to Lambda. (Runtime nodejs18.x.)
+[Sidecar] Deploying App\Sidecar\OgImage to Lambda. (Runtime nodejs20.x.)
           ↳ Function already exists, potentially updating code and configuration.
           ↳ Packaging function code.
           ↳ Package unchanged, reusing previous code package at s3://sidecar-us-east-2-XXX/sidecar/001-79a5915eaec296be04a0f4fb7cc80e40.zip.
           ↳ Function code and configuration are unchanged! Not updating anything. [tl! focus]
 [Sidecar] Activating function App\Sidecar\OgImage.
           ↳ Activating Version 1 of SC-Laravel-local-Sidecar-OgImage.
-``` 
-
-
-
-
+```

--- a/docs/functions/deploying.md
+++ b/docs/functions/deploying.md
@@ -172,7 +172,7 @@ In the event that neither the code nor function configuration have changed, Side
 You will see output similar to the following:
 
 ```text
-[Sidecar] Deploying App\Sidecar\OgImage to Lambda. (Runtime nodejs12.x.)
+[Sidecar] Deploying App\Sidecar\OgImage to Lambda. (Runtime nodejs18.x.)
           ↳ Function already exists, potentially updating code and configuration.
           ↳ Packaging function code.
           ↳ Package unchanged, reusing previous code package at s3://sidecar-us-east-2-XXX/sidecar/001-79a5915eaec296be04a0f4fb7cc80e40.zip.

--- a/docs/functions/hooks.md
+++ b/docs/functions/hooks.md
@@ -11,7 +11,7 @@ The following four methods are available to you on every Sidecar function:
 - `beforeActivation`
 - `afterActivation`
 
-## Example: Before Deployment 
+## Example: Before Deployment
 
 The `beforeDeployment` hook is a great place to run a build step if your function requires it. We'll be using the `ncc build` command mentioned in the [Handlers & Packages](handlers-and-packages#compiling-your-handler-with-ncc) section for this example.
 
@@ -44,7 +44,7 @@ With this in place, you'll see something like this in your logs:
 ```text
 [Sidecar] Deploying App\Sidecar\Example to Lambda as `SC-App-local-Sidecar-Example`.
           ↳ Environment: local
-          ↳ Runtime: nodejs18.x
+          ↳ Runtime: nodejs20.x
           ↳ Compiling bundle with NCC.  [tl! focus]
           ↳ Running `ncc build resources/lambda/image.js -o resources/lambda/dist`  [tl! focus]
           ↳ Bundle compiled!  [tl! focus]

--- a/docs/functions/hooks.md
+++ b/docs/functions/hooks.md
@@ -44,7 +44,7 @@ With this in place, you'll see something like this in your logs:
 ```text
 [Sidecar] Deploying App\Sidecar\Example to Lambda as `SC-App-local-Sidecar-Example`.
           ↳ Environment: local
-          ↳ Runtime: nodejs14.x
+          ↳ Runtime: nodejs18.x
           ↳ Compiling bundle with NCC.  [tl! focus]
           ↳ Running `ncc build resources/lambda/image.js -o resources/lambda/dist`  [tl! focus]
           ↳ Bundle compiled!  [tl! focus]

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -10,21 +10,20 @@ You can write functions in any of the following runtimes and execute them straig
 - Node.js 20
 - Node.js 18
 - Node.js 16
-- Node.js 14
+- Python 3.12
 - Python 3.11
 - Python 3.10
 - Python 3.9
 - Python 3.8
-- Python 3.7
-- Ruby 3.2
-- Ruby 2.7
+- Java 21
 - Java 17
 - Java 11
 - Java 8
-- Go 1.x
 - .NET 7
 - .NET 6
-- Custom runtime
+- Ruby 3.2
+- OS-only runtime (Amazon Linux 2023)
+- OS-only runtime (Amazon Linux 2)
 
 Any runtime that [Lambda supports](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html), you can use!
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -10,6 +10,7 @@ You can write functions in any of the following runtimes and execute them straig
 - Node.js 18
 - Node.js 16
 - Node.js 14
+- Python 3.11
 - Python 3.10
 - Python 3.9
 - Python 3.8

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,16 +7,22 @@ It works with _any_ Laravel 7, 8, 9 or 10 application, hosted _anywhere_, includ
 
 You can write functions in any of the following runtimes and execute them straight from PHP:
 
+- Node.js 18
 - Node.js 16
 - Node.js 14
-- Node.js 12
+- Python 3.10
+- Python 3.9
 - Python 3.8
 - Python 3.7
+- Ruby 3.2
 - Ruby 2.7
+- Java 17
 - Java 11
 - Java 8
 - Go 1.x
-- .NET Core 3.1
+- .NET 7
+- .NET 6
+- Custom runtime
 
 Any runtime that [Lambda supports](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html), you can use!
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,6 +7,7 @@ It works with _any_ Laravel 7, 8, 9 or 10 application, hosted _anywhere_, includ
 
 You can write functions in any of the following runtimes and execute them straight from PHP:
 
+- Node.js 20
 - Node.js 18
 - Node.js 16
 - Node.js 14

--- a/src/Exceptions/NoFunctionsRegisteredException.php
+++ b/src/Exceptions/NoFunctionsRegisteredException.php
@@ -9,7 +9,7 @@ use Throwable;
 
 class NoFunctionsRegisteredException extends SidecarException
 {
-    public function __construct($message = '', $code = 0, Throwable $previous = null)
+    public function __construct($message = '', $code = 0, ?Throwable $previous = null)
     {
         $message = "No Sidecar functions have been configured. \n" .
             "Please check your config/sidecar.php file to ensure you have registered your functions. \n" .

--- a/src/LambdaFunction.php
+++ b/src/LambdaFunction.php
@@ -231,7 +231,7 @@ abstract class LambdaFunction
      */
     public function runtime()
     {
-        return Runtime::NODEJS_14;
+        return Runtime::NODEJS_18;
     }
 
     /**

--- a/src/LambdaFunction.php
+++ b/src/LambdaFunction.php
@@ -231,7 +231,7 @@ abstract class LambdaFunction
      */
     public function runtime()
     {
-        return Runtime::NODEJS_18;
+        return Runtime::NODEJS_14;
     }
 
     /**

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -22,7 +22,7 @@ use Throwable;
 
 class Manager
 {
-    use Macroable, HandlesLogging, ManagesEnvironments;
+    use HandlesLogging, Macroable, ManagesEnvironments;
 
     /**
      * @var string

--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -4,11 +4,13 @@ namespace Hammerstone\Sidecar;
 
 abstract class Runtime
 {
+    public const NODEJS_18 = 'nodejs18.x';
+
     public const NODEJS_16 = 'nodejs16.x';
 
     public const NODEJS_14 = 'nodejs14.x';
 
-    public const NODEJS_12 = 'nodejs12.x';
+    public const PYTHON_310 = 'python3.10';
 
     public const PYTHON_39 = 'python3.9';
 
@@ -16,7 +18,11 @@ abstract class Runtime
 
     public const PYTHON_37 = 'python3.7';
 
+    public const RUBY_32 = 'ruby3.2';
+
     public const RUBY_27 = 'ruby2.7';
+
+    public const JAVA_17 = 'java17';
 
     public const JAVA_11 = 'java11';
 
@@ -26,9 +32,11 @@ abstract class Runtime
 
     public const GO_1X = 'go1.x';
 
+    public const DOT_NET_7 = 'dotnet7';
+
     public const DOT_NET_6 = 'dotnet6';
 
-    public const DOT_NET_31 = 'dotnetcore3.1';
-
     public const PROVIDED_AL2 = 'provided.al2';
+
+    public const PROVIDED = 'provided';
 }

--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -4,6 +4,8 @@ namespace Hammerstone\Sidecar;
 
 abstract class Runtime
 {
+    public const NODEJS_20 = 'nodejs20.x';
+
     public const NODEJS_18 = 'nodejs18.x';
 
     public const NODEJS_16 = 'nodejs16.x';

--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -10,7 +10,10 @@ abstract class Runtime
 
     public const NODEJS_16 = 'nodejs16.x';
 
+    /** @deprecated */
     public const NODEJS_14 = 'nodejs14.x';
+
+    public const PYTHON_312 = 'python3.12';
 
     public const PYTHON_311 = 'python3.11';
 
@@ -20,11 +23,10 @@ abstract class Runtime
 
     public const PYTHON_38 = 'python3.8';
 
+    /** @deprecated */
     public const PYTHON_37 = 'python3.7';
 
-    public const RUBY_32 = 'ruby3.2';
-
-    public const RUBY_27 = 'ruby2.7';
+    public const JAVA_21 = 'java21';
 
     public const JAVA_17 = 'java17';
 
@@ -32,15 +34,25 @@ abstract class Runtime
 
     public const JAVA_8_LINUX2 = 'java8.al2';
 
+    /** @deprecated */
     public const JAVA_8 = 'java8';
-
-    public const GO_1X = 'go1.x';
 
     public const DOT_NET_7 = 'dotnet7';
 
     public const DOT_NET_6 = 'dotnet6';
 
+    public const RUBY_32 = 'ruby3.2';
+
+    /** @deprecated */
+    public const RUBY_27 = 'ruby2.7';
+
+    /** @deprecated */
+    public const GO_1X = 'go1.x';
+
+    public const PROVIDED_AL2023 = 'provided.al2023';
+
     public const PROVIDED_AL2 = 'provided.al2';
 
+    /** @deprecated */
     public const PROVIDED = 'provided';
 }

--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -10,6 +10,8 @@ abstract class Runtime
 
     public const NODEJS_14 = 'nodejs14.x';
 
+    public const PYTHON_311 = 'python3.11';
+
     public const PYTHON_310 = 'python3.10';
 
     public const PYTHON_39 = 'python3.9';


### PR DESCRIPTION
This PR updates the list of supported runtimes to the current supported runtimes listed in the [Lambda runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) docs page.

This PR also updates the default runtime for Lambda Functions to be latest Node.js LTS version.

Last but not least, this PR also updated the docs to be consistent with the list of Lambda Runtimes