### PR TITLE
Added option to configure number of backtraces in error message

### DIFF
--- a/src/Results/SettledResult.php
+++ b/src/Results/SettledResult.php
@@ -90,11 +90,13 @@ class SettledResult implements Responsable, ResultContract
     }
 
     /**
+     * @param ?int $numberOfBacktraces
+     *
      * Throw an exception if there was an error, otherwise do nothing.
      *
      * @throws Exception
      */
-    public function throw()
+    public function throw(?int $numberOfBacktraces)
     {
         if (!$this->isError()) {
             return $this;
@@ -102,7 +104,7 @@ class SettledResult implements Responsable, ResultContract
 
         throw new LambdaExecutionException(sprintf('Lambda Execution Exception for %s: "%s".', ...[
             get_class($this->function),
-            $this->errorAsString()
+            $this->errorAsString($numberOfBacktraces)
         ]));
     }
 
@@ -187,7 +189,7 @@ class SettledResult implements Responsable, ResultContract
         return Arr::get($this->body(), 'trace', []);
     }
 
-    public function errorAsString()
+    public function errorAsString(int $numberOfBacktraces = 2)
     {
         if (!$this->isError()) {
             return '';
@@ -195,8 +197,8 @@ class SettledResult implements Responsable, ResultContract
 
         $message = Arr::get($this->body(), 'errorMessage', 'Unknown error.');
 
-        // Only the first two backtraces (plus the error) for the string.
-        $trace = array_slice($this->trace(), 0, 3);
+        // Only the number of backtraces (plus the error) for the string.
+        $trace = array_slice($this->trace(), 0, $numberOfBacktraces + 1);
         $trace = implode(' ', array_map('trim', $trace));
 
         if ($trace) {


### PR DESCRIPTION
Fixes https://github.com/hammerstonedev/sidecar/issues/130 making the number of backtraces configurable.

$handler::execute($page)->throw(8)