### PR TITLE
Update Zipstream dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "illuminate/support": "^8.0|^9.0|^10",
         "illuminate/filesystem": "^8.0|^9.0|^10",
         "illuminate/console": "^8.0|^9.0|^10",
-        "maennchen/zipstream-php": "^2.1",
+        "maennchen/zipstream-php": "^3.0",
         "guzzlehttp/guzzle": "^6.3|^7.2",
         "aws/aws-sdk-php": "^3.216.1"
     },


### PR DESCRIPTION
Zipstream v2 requires `psr/http-message` v1. I wanted to use sidecar in my project but I already had `psr/http-message` v2 in place. Updating Zipstream to v3 allows `psr/http-message` v2 but requires other changes related to argument format.