### PR TITLE
Add Support for Laravel 11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ 7.4, 8.0, 8.1, 8.2 ]
-        laravel: [ 8.*, 9.*, 10.* ]
+        php: [ 7.4, 8.0, 8.1, 8.2, 8.3 ]
+        laravel: [ 8.*, 9.*, 10.*, 11.* ]
         guzzle: [ 6.*, 7.* ]
         dependency-version: [ prefer-lowest, prefer-stable ]
         include:
@@ -27,6 +27,9 @@ jobs:
 
           - laravel: 10.*
             testbench: 8.*
+
+          - laravel: 11.*
+            testbench: 9.*
 
         exclude:
             # PHP 8.1 requires Laravel 8.65, so skip lowest
@@ -58,6 +61,18 @@ jobs:
 
             # Laravel 10 requires Guzzle ^7.2
           - laravel: 10.*
+            guzzle: 6.*
+
+            # Laravel 11 requires PHP 8.2
+          - laravel: 11.*
+            php: 7.4
+          - laravel: 11.*
+            php: 8.0
+          - laravel: 11.*
+            php: 8.1
+
+            # Laravel 11 requires Guzzle ^7.2
+          - laravel: 11.*
             guzzle: 6.*
 
     name: P${{ matrix.php }} / L${{ matrix.laravel }} / G${{ matrix.guzzle }} / ${{ matrix.dependency-version }}

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
             "Hammerstone\\Sidecar\\Tests\\": "tests/"
         }
     },
-    "minimum-stability": "dev",
     "extra": {
         "laravel": {
             "providers": [

--- a/composer.json
+++ b/composer.json
@@ -11,17 +11,17 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "illuminate/support": "^8.0|^9.0|^10",
-        "illuminate/filesystem": "^8.0|^9.0|^10",
-        "illuminate/console": "^8.0|^9.0|^10",
+        "illuminate/support": "^8.0|^9.0|^10|^11",
+        "illuminate/filesystem": "^8.0|^9.0|^10|^11",
+        "illuminate/console": "^8.0|^9.0|^10|^11",
         "maennchen/zipstream-php": "^2.1",
         "guzzlehttp/guzzle": "^6.3|^7.2",
         "aws/aws-sdk-php": "^3.216.1"
     },
     "require-dev": {
-        "orchestra/testbench": "^5|^6|^7|^8",
+        "orchestra/testbench": "^5|^6|^7|^8|^9",
         "mockery/mockery": "^1.3.3",
-        "phpunit/phpunit": ">=8.5.23|^9"
+        "phpunit/phpunit": ">=8.5.23|^9|^10"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
             "Hammerstone\\Sidecar\\Tests\\": "tests/"
         }
     },
+    "minimum-stability": "dev",
     "extra": {
         "laravel": {
             "providers": [


### PR DESCRIPTION
This PR updates the requirements in composer.json to support Laravel 11.

I ran the test suite on Github Actions in my fork. Results can be found [here](https://github.com/stefanzweifel/sidecar/actions/runs/7768056332). (I temporarily added `"minimum-stability": "dev"` to run the tests)

The `precedence_is_correct` test is currently failing.

```shell
1) Hammerstone\Sidecar\Tests\Unit\EnvironmentTest::precedence_is_correct
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'app_env'
+'testing'
```

Maybe someone with more knowledge about the codebase or the new Laravel 11 changes knows what's going on here.