### PR TITLE
Add .NET 8 and Ruby 3.3 runtime options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ You can write functions in any of the following runtimes and execute them straig
 - Java 17
 - Java 11
 - Java 8
+- .NET 8
 - .NET 7
 - .NET 6
+- Ruby 3.3
 - Ruby 3.2
 - OS-only runtime (Amazon Linux 2023)
 - OS-only runtime (Amazon Linux 2)

--- a/docs/functions/customization.md
+++ b/docs/functions/customization.md
@@ -19,8 +19,10 @@ Lambda supports multiple languages through the use of runtimes. You can choose a
 - Java 17: `java17`
 - Java 11: `java11`
 - Java 8: `java8.al2`
+- .NET 8: `dotnet8`
 - .NET 7: `dotnet7`
 - .NET 6: `dotnet6`
+- Ruby 3.3: `ruby3.3`
 - Ruby 3.2: `ruby3.2`
 - OS-only runtime (Amazon Linux 2023): `provided.al2023`
 - OS-only runtime (Amazon Linux 2): `provided.al2`

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -19,8 +19,10 @@ You can write functions in any of the following runtimes and execute them straig
 - Java 17
 - Java 11
 - Java 8
+- .NET 8
 - .NET 7
 - .NET 6
+- Ruby 3.3
 - Ruby 3.2
 - OS-only runtime (Amazon Linux 2023)
 - OS-only runtime (Amazon Linux 2)

--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -37,9 +37,13 @@ abstract class Runtime
     /** @deprecated */
     public const JAVA_8 = 'java8';
 
+    public const DOT_NET_8 = 'dotnet8';
+
     public const DOT_NET_7 = 'dotnet7';
 
     public const DOT_NET_6 = 'dotnet6';
+
+    public const RUBY_33 = 'ruby3.3';
 
     public const RUBY_32 = 'ruby3.2';
 


### PR DESCRIPTION
This PR adds .NET 8 and Ruby 3.3 runtime options.

No runtimes have been deprecated since the last release, so none of the runtimes have been marked as deprecated.