### PR TITLE
SettledResult isError fix

### DIFF
--- a/src/Results/SettledResult.php
+++ b/src/Results/SettledResult.php
@@ -58,7 +58,7 @@ class SettledResult implements Responsable, ResultContract
      */
     public function isError()
     {
-        return $this->raw->get('FunctionError') !== '';
+         return $this->raw->hasKey('FunctionError') && $this->raw->get('FunctionError') !== '';
     }
 
     /**


### PR DESCRIPTION
Fixes #161 

Updates isError to handle missing FunctionError key as result of latest aws-sdk-php package.
