### PR TITLE
Avoids error when FunctionError key is not present

### DIFF
--- a/src/Results/SettledResult.php
+++ b/src/Results/SettledResult.php
@@ -58,7 +58,7 @@ class SettledResult implements Responsable, ResultContract
      */
     public function isError()
     {
-        return $this->raw->get('FunctionError') !== '';
+        return $this->raw->hasKey('FunctionError') && $this->raw->get('FunctionError') !== '';
     }
 
     /**


### PR DESCRIPTION
Using the latest version of the `aws/aws-sdk-php` package (currently `3.356.0`), I've noticed that the `FunctionError` key is not present in the `$data` property of the `Aws/Result` object when a request is successful.

When this happens, the `->get('FunctionError')` method call returns `null`, rather than an empty string. 

Because the `isError` method in this package returns `true` when that value is (strictly) anything except an empty string, it is causing a false-positive when the value is null.

The `Aws/Result` class provides a handy `hasKey` method that will return a boolean value representing if a given array key exists in the result.

This PR adds use of this `hasKey` function to ensure the 'FunctionError' key exists (in addition to the existing empty string check).