### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,15 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/filesystem": "^8|^9|^10|^11|^12.0",
-        "illuminate/console": "^8|^9|^10|^11|^12.0",
-        "illuminate/support": "^8|^9|^10|^11|^12.0",
+        "illuminate/filesystem": "^8|^9|^10|^11|^12.0|^13.0",
+        "illuminate/console": "^8|^9|^10|^11|^12.0|^13.0",
+        "illuminate/support": "^8|^9|^10|^11|^12.0|^13.0",
         "maennchen/zipstream-php": "^3.1",
         "guzzlehttp/guzzle": "^6.5.8|^7.2",
         "aws/aws-sdk-php": "^3.216.1"
     },
     "require-dev": {
-        "orchestra/testbench": "^5|^6|^7|^8|^9|^10.0",
+        "orchestra/testbench": "^5|^6|^7|^8|^9|^10.0|^11.0",
         "mockery/mockery": "^1.3.3",
         "phpunit/phpunit": ">=8.5.23|^9|^10"
     },


### PR DESCRIPTION
## Summary

- Add `^13.0` to the `illuminate/filesystem`, `illuminate/console`, and `illuminate/support` version constraints
- Add `^11.0` to the `orchestra/testbench` version constraint for Laravel 13 compatibility

## Details

This is a composer.json constraint-only change. Laravel 13 has no breaking changes affecting this package, so widening the version constraints is all that's needed.