### PR TITLE
Update Runtime and add deprecations

### DIFF
--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -4,10 +4,14 @@ namespace Hammerstone\Sidecar;
 
 abstract class Runtime
 {
+    public const NODEJS_24 = 'nodejs24.x';
+
     public const NODEJS_22 = 'nodejs22.x';
 
+    /** @deprecated */
     public const NODEJS_20 = 'nodejs20.x';
 
+    /** @deprecated */
     public const NODEJS_18 = 'nodejs18.x';
 
     /** @deprecated */
@@ -15,6 +19,8 @@ abstract class Runtime
 
     /** @deprecated */
     public const NODEJS_14 = 'nodejs14.x';
+
+    public const PYTHON_314 = 'python3.14';
 
     public const PYTHON_313 = 'python3.13';
 
@@ -24,6 +30,7 @@ abstract class Runtime
 
     public const PYTHON_310 = 'python3.10';
 
+    /** @deprecated */
     public const PYTHON_39 = 'python3.9';
 
     /** @deprecated */
@@ -31,6 +38,8 @@ abstract class Runtime
 
     /** @deprecated */
     public const PYTHON_37 = 'python3.7';
+
+    public const JAVA_25 = 'java25';
 
     public const JAVA_21 = 'java21';
 
@@ -43,17 +52,25 @@ abstract class Runtime
     /** @deprecated */
     public const JAVA_8 = 'java8';
 
+    public const DOT_NET_10 = 'dotnet10';
+
+    public const DOT_NET_9 = 'dotnet9';
+
     public const DOT_NET_8 = 'dotnet8';
 
     /** @deprecated */
     public const DOT_NET_7 = 'dotnet7';
 
+    /** @deprecated */
     public const DOT_NET_6 = 'dotnet6';
+
+    public const RUBY_40 = 'ruby4.0';
 
     public const RUBY_34 = 'ruby3.4';
 
     public const RUBY_33 = 'ruby3.3';
 
+    /** @deprecated */
     public const RUBY_32 = 'ruby3.2';
 
     /** @deprecated */


### PR DESCRIPTION
This pull request updates the `Runtime` class to add support for several new language runtimes and deprecates some older ones. The main goal is to keep the supported runtimes up to date with the latest versions for Node.js, Python, Java, .NET, and Ruby.

**New runtime versions added:**

- Node.js: Added support for `NODEJS_24` (`nodejs24.x`)
- Python: Added support for `PYTHON_314` (`python3.14`)
- Java: Added support for `JAVA_25` (`java25`)
- .NET: Added support for `DOT_NET_10` (`dotnet10`) and `DOT_NET_9` (`dotnet9`)
- Ruby: Added support for `RUBY_40` (`ruby4.0`)

**Deprecations:**

- Marked `PYTHON_39` (`python3.9`), `DOT_NET_6` (`dotnet6`), and `RUBY_32` (`ruby3.2`) as deprecated to signal that these versions should no longer be used for new projects. [[1]](diffhunk://#diff-c038f4cc1dd9f058023ae02bf027e143cae0f46fe4cc0ee9d84edbfc85609b38R33) [[2]](diffhunk://#diff-c038f4cc1dd9f058023ae02bf027e143cae0f46fe4cc0ee9d84edbfc85609b38R55-R73)

These changes ensure the `Runtime` class stays current with the latest language runtime releases and encourages migration away from older, deprecated versions.